### PR TITLE
[Format] align trailing comment

### DIFF
--- a/format_peric.sh
+++ b/format_peric.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if [ ! -d ~/Programme/iec/IB-Peric/ ] || [ ! -d ~/Programme/iec/flint/ ]; then
+    echo "Not on Jonas work station"
+    exit 0
+fi
+
+cd ~/Programme/iec/IB-Peric/source
+
+git stash
+python3 ~/Programme/iec/flint/src/flint.py format mod_*.f90 prog.f90 Grid/*.f90 Geometry/geom.f90 Geometry/mod_geometry.f90
+STATUS=$?
+
+# git checkout -- mod_*.f90 prof.f90 Grid/*.f90 Geometry/geom.f90 Geometry/mod_geometry.f90
+# git stash apply
+
+echo "Restore with:"
+echo "$ git checkout -- mod_kinds.f90 mod_constants.f90 mod_solver.f90 mod_utility.f90 prog.f90 Grid/mod_multigrid.f90 Geometry/geom.f90 Geometry/mod_geometry.f90"
+echo "$ git stash apply"
+
+exit $STATUS

--- a/src/flint.py
+++ b/src/flint.py
@@ -11,6 +11,7 @@ import sys
 from check.check_implicit_none import CheckImplicitNone
 from check.check_format_label import CheckFormatLabel
 from format.format_align_colon import FormatAlignColon
+from format.format_trailing_comment import FormatAlignTrailingComment
 from file_io import CodeFile
 
 
@@ -63,7 +64,8 @@ def handle_formatting(args):
     :args: Command line arguments passed to the command.
     """
     all_formatters = {
-        "align-double-colon": FormatAlignColon,
+        # "align-double-colon": FormatAlignColon,
+        "align-trailing-comment": FormatAlignTrailingComment,
     }
 
     # If listing is wanted, only that will be done.
@@ -131,7 +133,7 @@ def main():
         "-f",
         "--formatters",
         type=str,
-        default="align-double-colon",
+        default="align-trailing-comment",
         help="Comma separated list of formatters to apply in the given order.")
     parse_format.add_argument(
         "files", nargs="*", help="List of fortran files to analyse")

--- a/src/flint.py
+++ b/src/flint.py
@@ -64,7 +64,7 @@ def handle_formatting(args):
     :args: Command line arguments passed to the command.
     """
     all_formatters = {
-        # "align-double-colon": FormatAlignColon,
+        "align-double-colon": FormatAlignColon,
         "align-trailing-comment": FormatAlignTrailingComment,
     }
 
@@ -133,7 +133,7 @@ def main():
         "-f",
         "--formatters",
         type=str,
-        default="align-trailing-comment",
+        default="align-double-colon,align-trailing-comment",
         help="Comma separated list of formatters to apply in the given order.")
     parse_format.add_argument(
         "files", nargs="*", help="List of fortran files to analyse")

--- a/src/format/align.py
+++ b/src/format/align.py
@@ -27,7 +27,7 @@ def insert_whitespace(line: str, old_anchor: int, new_anchor):
     return line[:old_anchor] + " " * necessary_spaces + line[old_anchor:]
 
 
-def find_anchor(lines: list, anchor_str: str, skip_regex = None):
+def find_anchor(lines: list, anchor_str: str, skip_regex=None):
     """
     Find the position of the anchor_str (from left) for every line and
     return a list of indices to that anchor.
@@ -47,4 +47,3 @@ def find_anchor(lines: list, anchor_str: str, skip_regex = None):
             positions.append(line.find(anchor_str))
 
     return positions
-

--- a/src/format/format_align_colon.py
+++ b/src/format/format_align_colon.py
@@ -19,10 +19,11 @@ real(8)    :: some_real
 import logging
 import re
 
-from format.abstract_formatter import AbstractFormatter
-from format.align import insert_whitespace, find_anchor
 from common_matcher import match_line, match_blank_line, match_commented_line
 from file_io import CodeFile
+from format.abstract_formatter import AbstractFormatter
+from format.align import insert_whitespace, find_anchor
+from format.utility import overwrite_lines
 
 __regex_variable_colon = re.compile(r'[^!]+::(.*)$')
 
@@ -37,7 +38,7 @@ def _match_variable_colon(line):
     return match_line(__regex_variable_colon, line)
 
 
-def _align_colons(lines):
+def _align_colons(lines: list):
     """
     Algorithm to align the colons of subsequent lines.
 
@@ -135,18 +136,12 @@ class FormatAlignColon(AbstractFormatter):
             if in_decl_list:
                 self._log.debug("ending declaration section")
                 in_decl_list = False
-                assert decl_start >= 0
-                assert decl_end >= 0
+                assert decl_start > 0
+                assert decl_end > 0
                 new = _align_colons(self._formatted_lines[decl_start:decl_end])
 
-                # Overwrite for formatting.
-                for new_line_idx, old_line_idx in enumerate(
-                        range(decl_start, decl_end)):
-                    self._log.debug("Overwriting:")
-                    self._log.debug("Old: {}".format(
-                        self._formatted_lines[old_line_idx]))
-                    self._log.debug("New: {}".format(new[new_line_idx]))
-                    self._formatted_lines[old_line_idx] = new[new_line_idx]
+                overwrite_lines(self._formatted_lines, new, decl_start,
+                                decl_end)
 
                 decl_start = -1
                 decl_end = -1

--- a/src/format/format_trailing_comment.py
+++ b/src/format/format_trailing_comment.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Implement a formatter that aligns trailing comments in subsequent
+line. The line sequence end with an empty or non-comment line.
+
+Example:
+
+```fortran
+integer(8) :: some_int ! asdlkja
+real(8) :: some_real       ! alskdj
+  ! continue the comment
+
+! not in sequence
+```
+becomes
+```fortran
+integer(8) :: some_int     ! asdlkja
+real(8)    :: some_real    ! alskdj
+                           ! continue the comment
+
+! not in sequence
+```
+"""
+
+import logging
+import re
+from common_matcher import match_line, match_blank_line, match_commented_line
+from file_io import CodeFile
+from format.abstract_formatter import AbstractFormatter
+from format.align import insert_whitespace, find_anchor
+from format.utility import overwrite_lines
+
+REGEX_TRAILING_COMMENT = re.compile(r'^(.*)([^\\]|\s+)!(.*)$')
+REGEX_EXCLAMATION_IN_STRING = re.compile(r'^.*((".*!.*")|(\'.*!.*\')).*$')
+REGEX_OMP_DIRECTIVE = re.compile(r'^!\$OMP(.*)$')
+
+
+def _match_trailing_comment(line):
+    """
+    Match if a line contains a comment, but not only whitespace
+    if front of the comment.
+    """
+    res = not match_commented_line(line) and \
+          match_line(REGEX_TRAILING_COMMENT, line)
+    return res
+
+def _match_omp_directive(line):
+    """
+    Match if a comment is a OMP directive.
+    Use this function to filter the alignments.
+    """
+    return match_line(REGEX_OMP_DIRECTIVE, line)
+
+
+def _align_comments(lines: list):
+    """
+    Algorithm to align the trailing comments of ssubsequent lines is same
+    as for `_align_colons`.
+    Ignore OMP directives while aligning
+    """
+    if len(lines) == 0:
+        return []
+
+    comment_posi = find_anchor(lines, "!", skip_regex=_match_omp_directive)
+    (max_comment, max_line) = max((v, i) for i, v in enumerate(comment_posi))
+
+    formatted_lines = []
+
+    for i, line in enumerate(lines):
+        if not _match_omp_directive(line):
+            line = insert_whitespace(line, comment_posi[i], max_comment)
+        formatted_lines.append(line)
+
+    return formatted_lines
+
+
+class FormatAlignTrailingComment(AbstractFormatter):
+    """
+    Example:
+
+    ```fortran
+    integer(8) :: some_int ! asdlkja
+    real(8) :: some_real       ! alskdj
+      ! continue the comment
+
+    ! not in sequence
+    ```
+    becomes
+    ```fortran
+    integer(8) :: some_int     ! asdlkja
+    real(8)    :: some_real    ! alskdj
+                               ! continue the comment
+
+    ! not in sequence
+    ```
+
+    Limitation:
+    The formatting will fail if the line contains a string containing a '!'
+    and a trailing comment. This might result in a mess but should be uncommon.
+    """
+
+    def __init__(self, f_file: CodeFile):
+        super(FormatAlignTrailingComment, self).__init__(f_file)
+        self._log = logging.getLogger(__file__ + "::align_trailing_comment")
+
+    @classmethod
+    def help(self):
+        return "Align subsequent trailing comments. End with blank or non-comment line"
+
+    def format(self):
+        in_sequence = False
+        seq_start = -1
+        seq_end = -1
+
+        for (i, line) in enumerate(self._formatted_lines):
+            # Start a sequence if there is a trailing comment.
+            if not in_sequence and _match_trailing_comment(line):
+                self._log.debug("starting sequence at %d" % i)
+                seq_start = i
+                seq_end = i + 1
+                in_sequence = True
+                continue
+
+            # Advance sequence for a following trailing comment.
+            elif in_sequence and _match_trailing_comment(line):
+                self._log.debug("advancing sequence to %d" % (i + 1))
+                seq_end = i + 1
+                continue
+
+            # Maybe there is a continuation comment, align that, too.
+            elif in_sequence and match_commented_line(line):
+                self._log.debug("advancing sequence to %d" % (i + 1))
+                seq_end = i + 1
+                continue
+
+            # End the sequence for every other line.
+            elif in_sequence:
+                self._log.debug("ending sequence at %d" % i)
+                assert seq_start > 0
+                assert seq_end > 0
+                # Align all trailing comments
+                new = _align_comments(self._formatted_lines[seq_start:seq_end])
+
+                overwrite_lines(self._formatted_lines, new, seq_start, seq_end)
+
+                # End sequence
+                in_sequence = False
+                seq_start = -1
+                seq_end = -1
+                continue
+
+            # Ignore the rest of possible lines
+            continue
+
+        return self.formatted_lines()

--- a/src/format/test_format_trailing_comment.py
+++ b/src/format/test_format_trailing_comment.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Implement unit tests for the formatter to align trailing comments.
+"""
+
+import unittest
+from format_trailing_comment import _match_trailing_comment,\
+                                    _match_omp_directive
+
+
+class TestFormatTrailingComment(unittest.TestCase):
+    def test_match_trailing_comment(self):
+        self.assertTrue(_match_trailing_comment("alskdjlk ! ljasd "))
+        self.assertTrue(_match_trailing_comment(" \t alskdjlk! ljasd "))
+        self.assertTrue(_match_trailing_comment(" alskdjlk!ljasd "))
+        self.assertTrue(_match_trailing_comment(" \"alskdjlk\" !ljasd "))
+        self.assertTrue(_match_trailing_comment(" 'alskdjlk' !ljasd "))
+        # Its all just for fun...
+        # self.assertTrue(_match_trailing_comment(" \"alskdjlk ! \" !ljasd "))
+        # self.assertTrue(_match_trailing_comment(" 'alskdjlk ! ' !ljasd "))
+        self.assertTrue(_match_trailing_comment(" \"\" !ljasd "))
+        self.assertTrue(_match_trailing_comment(" '' !ljasd "))
+
+        self.assertFalse(_match_trailing_comment("! alksjlkd"))
+        self.assertFalse(_match_trailing_comment("  ! alksjlkd"))
+        self.assertFalse(_match_trailing_comment("  !alksjlkd"))
+        self.assertFalse(_match_trailing_comment("  \\!alksjlkd"))
+        self.assertFalse(_match_trailing_comment("  \\!"))
+        # self.assertFalse(_match_trailing_comment("  \" asdlkj!\""))
+        # self.assertFalse(_match_trailing_comment("  ' asdlkj!' asd"))
+        self.assertFalse(_match_trailing_comment("  \"\""))
+        self.assertFalse(_match_trailing_comment("  ''"))
+
+    def test_match_omp_directive(self):
+        self.assertTrue(_match_omp_directive("!$OMP PARALLEL"))
+        self.assertTrue(_match_omp_directive("!$OMP"))
+        self.assertTrue(_match_omp_directive("!$OMP  "))
+
+        self.assertFalse(_match_omp_directive(" !$OMP"))
+        self.assertFalse(_match_omp_directive(" asdlkj !$OMP"))
+        self.assertFalse(_match_omp_directive(" $OMP"))
+        self.assertFalse(_match_omp_directive("!$ OMP"))
+        self.assertFalse(_match_omp_directive("!!$ OMP"))

--- a/src/format/utility.py
+++ b/src/format/utility.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Utility functions that are necessary for formatting.
+"""
+
+
+def overwrite_lines(overwritee: list, overwriter: list, start: int, end: int):
+    # Overwrite for formatting.
+    for new_line_idx, old_line_idx in enumerate(range(start, end)):
+        overwritee[old_line_idx] = overwriter[new_line_idx]


### PR DESCRIPTION
Align trailing comments, similar to colons.