### PR TITLE
[Refactor] FortranCode class hierarchy

### DIFF
--- a/src/check/abstract_check.py
+++ b/src/check/abstract_check.py
@@ -5,7 +5,7 @@ Define the abstract interface of all checks.
 """
 
 import abc
-from file_io import CodeFile
+from file_io import FortranCode
 
 
 class AbstractCheck(object):
@@ -16,7 +16,7 @@ class AbstractCheck(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, f_file: CodeFile):
+    def __init__(self, f_file: FortranCode):
         self._f_file = f_file
 
     @classmethod

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -9,33 +9,17 @@ import logging as log
 import os
 
 
-class CodeFile(object):
+class FortranCode(object):
     """
-    Represent a fortran file, handle IO and give an interface for
-    FIXITs.
+    Class that holds Fortran code.
+    This data is the basis for analyzers and formatters.
     """
 
-    def __init__(self, file_path):
-        """
-        Initialize the code file.
-
-        :file_path: Path of the fortran file.
-        If the path is relative, the prefix of the execution
-        directory is added.
-        """
-        self._log = log.getLogger(__file__)
-
-        self._log.debug("Set _file_path to %s" % os.path.abspath(file_path))
-        self._file_path = os.path.abspath(file_path)
-
+    def __init__(self, file_content: list = None):
         # List of strings the file consists of. Read in lazyly.
         # Both the original version and the case insenstive version.
-        self._original_file_content = None
-        self._insensitive_file_content = None
-
-    def path(self):
-        """Return the absolute path of the `CodeFile`."""
-        return self._file_path
+        self._original_file_content = file_content
+        self._insensitive_file_content = file_content
 
     def original_lines(self):
         """
@@ -57,9 +41,46 @@ class CodeFile(object):
             self.__read_file()
         return self._insensitive_file_content
 
-    def update_lines(self, lines):
+    def update_lines(self, lines: list):
         """Remove all current lines and overwrite them with `lines`."""
-        self.__assign_lines(lines)
+        self._assign_lines(lines)
+
+    def _assign_lines(self, iteratable):
+        """Assign every line in `iterabtable` to the content."""
+        self._original_file_content = []
+        self._insensitive_file_content = []
+
+        for line in iteratable:
+            self._log.debug("assigning: %s" % line)
+            self._original_file_content.append(line)
+            self._insensitive_file_content.append(line.lower())
+
+
+class CodeFile(FortranCode):
+    """
+    Represent a fortran file, handle IO and give an interface for
+    FIXITs.
+    """
+
+    def __init__(self, file_path: str):
+        """
+        Initialize the code file.
+
+        :file_path: Path of the fortran file.
+        If the path is relative, the prefix of the execution
+        directory is added.
+        """
+        super(CodeFile, self).__init__()
+        self._log = log.getLogger(__file__)
+
+        self._log.debug("Set _file_path to %s" % os.path.abspath(file_path))
+        self._file_path = os.path.abspath(file_path)
+
+        self.__read_file()
+
+    def path(self):
+        """Return the absolute path of the `CodeFile`."""
+        return self._file_path
 
     def write(self):
         """
@@ -75,14 +96,4 @@ class CodeFile(object):
         self._log.debug("Reading the content of the file %s" % self._file_path)
 
         with open(self._file_path) as fortran_file:
-            self.__assign_lines(fortran_file)
-
-    def __assign_lines(self, iteratable):
-        """Assign every line in `iterabtable` to the content."""
-        self._original_file_content = []
-        self._insensitive_file_content = []
-
-        for line in iteratable:
-            self._log.debug("assigning: %s" % line)
-            self._original_file_content.append(line)
-            self._insensitive_file_content.append(line.lower())
+            self._assign_lines(fortran_file)

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -27,8 +27,6 @@ class FortranCode(object):
         :note: Use `insensitive_lines` for analysis.
         :note: The lines do include the \\n character.
         """
-        if self._original_file_content is None:
-            self.__read_file()
         return self._original_file_content
 
     def insensitive_lines(self):
@@ -37,8 +35,6 @@ class FortranCode(object):
         work with while analyzing.
         The lines do include the \\n character.
         """
-        if self._insensitive_file_content is None:
-            self.__read_file()
         return self._insensitive_file_content
 
     def update_lines(self, lines: list):
@@ -76,11 +72,30 @@ class CodeFile(FortranCode):
         self._log.debug("Set _file_path to %s" % os.path.abspath(file_path))
         self._file_path = os.path.abspath(file_path)
 
-        self.__read_file()
-
     def path(self):
         """Return the absolute path of the `CodeFile`."""
         return self._file_path
+
+    def original_lines(self):
+        """
+        Return the original content as list of lines.
+        :note: Use `insensitive_lines` for analysis.
+        :note: The lines do include the \\n character.
+        """
+        if self._original_file_content is None:
+            self.__read_file()
+        return self._original_file_content
+
+    def insensitive_lines(self):
+        """
+        Return a list of lines that are not case sensitive and better to
+        work with while analyzing.
+        The lines do include the \\n character.
+        """
+        if self._insensitive_file_content is None:
+            self.__read_file()
+        return self._insensitive_file_content
+
 
     def write(self):
         """

--- a/src/format/abstract_formatter.py
+++ b/src/format/abstract_formatter.py
@@ -6,7 +6,7 @@ Define the abstract interface of formatters.
 
 import abc
 import copy
-from file_io import CodeFile
+from file_io import FortranCode
 
 
 class AbstractFormatter(object):
@@ -16,7 +16,7 @@ class AbstractFormatter(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, f_file: CodeFile):
+    def __init__(self, f_file: FortranCode):
         self._f_file = f_file
         self._formatted_lines = copy.deepcopy(self._f_file.original_lines())
 

--- a/src/format/format_align_colon.py
+++ b/src/format/format_align_colon.py
@@ -113,6 +113,7 @@ class FormatAlignColon(AbstractFormatter):
 
             # Check if the deactivation mechanism matches
             if match_ignore_start(line):
+                self._log.debug("start block ignore")
                 in_ignore = True
 
                 in_decl_list = False
@@ -122,6 +123,7 @@ class FormatAlignColon(AbstractFormatter):
 
             if in_ignore:
                 if match_ignore_end(line):
+                    self._log.debug("end block ignore")
                     in_ignore = False
                 continue
 

--- a/src/format/test_format_align_colon.py
+++ b/src/format/test_format_align_colon.py
@@ -13,7 +13,7 @@ from file_io import CodeFile, FortranCode
 from format.format_align_colon import _match_variable_colon, _align_colons,\
                                       FormatAlignColon
 
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 
 class TestFormatAlignColor(unittest.TestCase):

--- a/src/format/test_format_align_colon.py
+++ b/src/format/test_format_align_colon.py
@@ -13,7 +13,7 @@ from file_io import CodeFile, FortranCode
 from format.format_align_colon import _match_variable_colon, _align_colons,\
                                       FormatAlignColon
 
-# logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 
 
 class TestFormatAlignColor(unittest.TestCase):
@@ -85,6 +85,7 @@ class TestFormatAlignColor(unittest.TestCase):
             "   integer(2) :: flag1  ! and have some weird code\n",
             "   integer(2)   :: flag2  ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
+            "\n",
         ]
         f_file = FortranCode(lines)
         f = FormatAlignColon(f_file)
@@ -102,6 +103,7 @@ class TestFormatAlignColor(unittest.TestCase):
             "   integer(2)     :: flag1  ! and have some weird code\n",
             "   integer(2)     :: flag2  ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
+            "\n",
         ]
         self.assertListEqual(expec, result)
 
@@ -125,45 +127,34 @@ class TestFormatAlignColor(unittest.TestCase):
         expected = [
             "  subroutine locate(l,n,array,var,pos)\n",
             "    !> Search the index of given value in sorted 1D array of unique values.\n",
-            "    !>\n",
-            "    !> It uses a binary search algorithm.\n",
+            "    !>\n", "    !> It uses a binary search algorithm.\n",
             "    implicit none\n",
             "    integer(int_p), intent(in)             :: l !> Initial guess of lower limit.\n",
             "    integer(int_p), intent(in)             :: n !> Size of array.\n",
             "    real(real_p), dimension(n), intent(in) :: array !> Sorted array to search.\n",
             "    real(real_p), intent(in)               :: var !> Value to find.\n",
             "    integer(int_p), intent(out)            :: pos !> Resulting index.\n",
-            "\n",
-            "    ! interrupting comment\n",
-            "\n",
+            "\n", "    ! interrupting comment\n", "\n",
             "    integer(int_p) :: jl !> Lower limit.\n",
             "    integer(int_p) :: jm !> Midpoint\n",
             "    integer(int_p) :: ju !> Upper limit\n",
             "    ! Initialize lower limit (L=0 FOR A NORMAL VECTOR!).\n",
-            "    jl=l\n",
-            "    ! Initialize upper limit.\n",
-            "    ju=jl+n+1\n",
+            "    jl=l\n", "    ! Initialize upper limit.\n", "    ju=jl+n+1\n",
             "    ! If we are not yet done compute a midpoint.\n",
-            "    pos=max(l+1,pos)\n",
-            "    return\n",
-            "  end subroutine locate\n",
-            "\n",
-            "\n",
+            "    pos=max(l+1,pos)\n", "    return\n",
+            "  end subroutine locate\n", "\n", "\n",
             "  pure function equal(arg1,arg2) result(res)\n",
             "      !> Returns whether the arguments are equal to machine precision\n",
             "      real(real_p), intent(in) :: arg1, arg2\n",
             "      logical                  :: res\n",
             "      res = (abs(arg1-arg2) < REALTOL)\n",
-            "  end function equal\n",
-            "\n",
+            "  end function equal\n", "\n",
             "  subroutine print_assertion_error(filename, line, error_msg)\n",
-            "    implicit none\n",
-            "\n",
+            "    implicit none\n", "\n",
             "    character(len=*), intent(in) :: filename\n",
             "    integer(int_p), intent(in)   :: line\n",
             "    character(len=*), intent(in) :: error_msg\n",
-            "    character(len=10)            :: line_string\n",
-            "\n",
+            "    character(len=10)            :: line_string\n", "\n",
             "    write (line_string, '(I2)') line\n",
             "    write (*,*) trim(filename) // \": \" // trim(line_string) // \": \" // trim(error_msg)\n",
             "  end subroutine print_assertion_error\n"
@@ -172,3 +163,7 @@ class TestFormatAlignColor(unittest.TestCase):
         new_file = f.formatted_lines()
 
         self.assertListEqual(expected, new_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/format/test_format_align_colon.py
+++ b/src/format/test_format_align_colon.py
@@ -9,7 +9,7 @@ import logging
 from os.path import dirname, join
 import unittest
 
-from file_io import CodeFile
+from file_io import CodeFile, FortranCode
 from format.format_align_colon import _match_variable_colon, _align_colons,\
                                       FormatAlignColon
 
@@ -76,7 +76,6 @@ class TestFormatAlignColor(unittest.TestCase):
         ]
         self.assertListEqual(expec, _align_colons(lines))
 
-    @unittest.skip
     def test_block_ignore(self):
         lines = [
             " !&<\n",
@@ -87,6 +86,11 @@ class TestFormatAlignColor(unittest.TestCase):
             "   integer(2)   :: flag2  ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
         ]
+        f_file = FortranCode(lines)
+        f = FormatAlignColon(f_file)
+        f.format()
+        result = f.formatted_lines()
+
         expec = [
             " !&<\n",
             " integer(8), intent(in) :: asldk\n",
@@ -96,7 +100,7 @@ class TestFormatAlignColor(unittest.TestCase):
             "   integer(2)     :: flag2  ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
         ]
-        self.assertListEqual(expec, _align_colons(lines))
+        self.assertListEqual(expec, result)
 
     def test_single_ignore(self):
         lines = [

--- a/src/format/test_format_align_colon.py
+++ b/src/format/test_format_align_colon.py
@@ -91,6 +91,9 @@ class TestFormatAlignColor(unittest.TestCase):
         f.format()
         result = f.formatted_lines()
 
+        for l in result:
+            print(l)
+
         expec = [
             " !&<\n",
             " integer(8), intent(in) :: asldk\n",

--- a/src/format/test_format_trailing_comment.py
+++ b/src/format/test_format_trailing_comment.py
@@ -5,8 +5,10 @@ Implement unit tests for the formatter to align trailing comments.
 """
 
 import unittest
+from file_io import FortranCode
 from format_trailing_comment import _match_trailing_comment,\
                                     _match_omp_directive, _align_comments
+from format_trailing_comment import FormatAlignTrailingComment
 
 
 class TestFormatTrailingComment(unittest.TestCase):
@@ -43,7 +45,6 @@ class TestFormatTrailingComment(unittest.TestCase):
         self.assertFalse(_match_omp_directive("!$ OMP"))
         self.assertFalse(_match_omp_directive("!!$ OMP"))
 
-    @unittest.skip
     def test_block_ignore(self):
         lines = [
             " !&<\n",
@@ -54,6 +55,11 @@ class TestFormatTrailingComment(unittest.TestCase):
             "   integer(2)   :: flag2  ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
         ]
+        f_file = FortranCode(lines)
+        f = FormatAlignTrailingComment(f_file)
+        f.format()
+        result = f.formatted_lines()
+
         expec = [
             " !&<\n",
             " integer(8), intent(in) :: asldk    ! alksjdasdlj\n",
@@ -63,7 +69,7 @@ class TestFormatTrailingComment(unittest.TestCase):
             "   integer(2)   :: flag2    ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
         ]
-        self.assertListEqual(expec, _align_comments(lines))
+        self.assertListEqual(expec, result)
 
     def test_single_ignore(self):
         lines = [

--- a/src/format/test_format_trailing_comment.py
+++ b/src/format/test_format_trailing_comment.py
@@ -54,6 +54,7 @@ class TestFormatTrailingComment(unittest.TestCase):
             "   integer(2) :: flag1  ! and have some weird code\n",
             "   integer(2)   :: flag2  ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
+            "\n",
         ]
         f_file = FortranCode(lines)
         f = FormatAlignTrailingComment(f_file)
@@ -68,6 +69,7 @@ class TestFormatTrailingComment(unittest.TestCase):
             "   integer(2) :: flag1      ! and have some weird code\n",
             "   integer(2)   :: flag2    ! and have some weird code\n",
             "   integer(2)     :: flag3  ! and have some weird code\n",
+            "\n",
         ]
         self.assertListEqual(expec, result)
 


### PR DESCRIPTION
Introduce a new base class to hold just the fortran code.
Handling of fortran files is a done via the (already existing) subclass `CodeFile`.

This change introduces the option to ignore some formatting changes for specific code ranges via the `fprettify` comments.

Closes #14 #12 